### PR TITLE
Add `TaskValueCtx`, a helper for wrapping a task that returns a value

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,6 @@ jobs:
         - oldstable
         - 1.19
         - 1.18
-        - 1.17
     steps:
 
     - name: Check out code

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dolmen-go/rendezvous
 
-go 1.17
+go 1.18

--- a/taskvalue.go
+++ b/taskvalue.go
@@ -33,3 +33,19 @@ func TaskValueCtx[T any](fetchT func(context.Context) (T, error)) (<-chan T, Tas
 		return err
 	}
 }
+
+// TaskValue wraps a function that returns a value and an error to make it a [Task]
+// for [WaitAll]. The value is returned via a channel, so the values of successful
+// tasks can be retrieved even if one task fails by checking for each task's channel if it
+// has a value.
+func TaskValue[T any](makeT func() (T, error)) (<-chan T, Task) {
+	ch := make(chan T, 1)
+	return ch, func() error {
+		defer close(ch)
+		v, err := makeT()
+		if err == nil {
+			ch <- v
+		}
+		return err
+	}
+}

--- a/taskvalue.go
+++ b/taskvalue.go
@@ -1,5 +1,3 @@
-//go:build go1.18
-
 /*
 Copyright 2023 Olivier Mengué
 
@@ -22,7 +20,8 @@ import "context"
 
 // TaskValueCtx wraps a function that returns a value and an error to make it a [TaskCtx]
 // for [WaitFirstError]. The value is returned via a channel, so the values of successful
-// tasks can be retrieved even if one task fails.
+// tasks can be retrieved even if one task fails by checking for each task's channel if it
+// has a value.
 func TaskValueCtx[T any](fetchT func(context.Context) (T, error)) (<-chan T, TaskCtx) {
 	ch := make(chan T, 1)
 	return ch, func(ctx context.Context) error {

--- a/taskvalue_go1.18.go
+++ b/taskvalue_go1.18.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+
+/*
+Copyright 2023 Olivier Mengué
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rendezvous
+
+import "context"
+
+// TaskValueCtx wraps a function that returns a value and an error to make it a [TaskCtx]
+// for [WaitFirstError]. The value is returned via a channel, so the values of successful
+// tasks can be retrieved even if one task fails.
+func TaskValueCtx[T any](fetchT func(context.Context) (T, error)) (<-chan T, TaskCtx) {
+	ch := make(chan T, 1)
+	return ch, func(ctx context.Context) error {
+		defer close(ch)
+		v, err := fetchT(ctx)
+		if err == nil {
+			ch <- v
+		}
+		return err
+	}
+}

--- a/taskvalue_test.go
+++ b/taskvalue_test.go
@@ -1,5 +1,3 @@
-//go:build go1.18
-
 /*
    Copyright 2023 Olivier Mengué
 

--- a/taskvalue_test.go
+++ b/taskvalue_test.go
@@ -1,0 +1,95 @@
+//go:build go1.18
+
+/*
+   Copyright 2023 Olivier Mengué
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rendezvous_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/dolmen-go/rendezvous"
+)
+
+func ExampleTaskValueCtx() {
+	aChan, aTask := rendezvous.TaskValueCtx(func(ctx context.Context) (int, error) {
+		return 42, nil
+	})
+	bChan, bTask := rendezvous.TaskValueCtx(func(ctx context.Context) (string, error) {
+		return "ok", nil
+	})
+	err := rendezvous.WaitFirstError(context.Background(), aTask, bTask)
+	if err != nil {
+		log.Fatal(err)
+	}
+	a, b := <-aChan, <-bChan
+	fmt.Println(a, b)
+	// Output:
+	// 42 ok
+}
+
+func TestTaskValueCtxFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	waitStart := make(chan struct{})
+
+	aChan, makeA := rendezvous.TaskValueCtx(func(ctx context.Context) (int, error) {
+		waitStart <- struct{}{}
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("makeA failure: %w", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+			return 42, nil
+		}
+	})
+
+	bChan, makeB := rendezvous.TaskValueCtx(func(ctx context.Context) (string, error) {
+		return "hello", nil
+	})
+
+	go func() {
+		<-waitStart
+		cancel()
+	}()
+
+	err := rendezvous.WaitFirstError(ctx, makeA, makeB)
+
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error context.Canceled expected, got %q", err)
+	}
+
+	_, ok := <-aChan
+
+	if ok {
+		t.Fatal("aChan should be empty because aChan has failed")
+	}
+
+	b, ok := <-bChan
+	if !ok {
+		t.Fatal("bChan should not be empty")
+	}
+	if b != "hello" {
+		t.Error("b value expected")
+	}
+}

--- a/taskvalue_test.go
+++ b/taskvalue_test.go
@@ -44,6 +44,23 @@ func ExampleTaskValueCtx() {
 	// 42 ok
 }
 
+func ExampleTaskValue() {
+	aChan, aTask := rendezvous.TaskValue(func() (int, error) {
+		return 42, nil
+	})
+	bChan, bTask := rendezvous.TaskValue(func() (string, error) {
+		return "ok", nil
+	})
+	errs := rendezvous.WaitAll(aTask, bTask)
+	if errs != nil {
+		log.Fatal(errs)
+	}
+	a, b := <-aChan, <-bChan
+	fmt.Println(a, b)
+	// Output:
+	// 42 ok
+}
+
 func TestTaskValueCtxFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
Add `TaskValueCtx` (and `TaskValue`) that use generics:
```go
// TaskValueCtx wraps a function that returns a value and an error to make it a [TaskCtx]
// for [WaitFirstError]. The value is returned via a channel, so the values of successful
// tasks can be retrieved even if one task fails.
func TaskValueCtx[T any](fetchT func(context.Context) (T, error)) (<-chan T, TaskCtx)
```

Usage example:
```go
func ExampleTaskValueCtx() {
	aChan, aTask := rendezvous.TaskValueCtx(func(ctx context.Context) (int, error) {
		return 42, nil
	})
	bChan, bTask := rendezvous.TaskValueCtx(func(ctx context.Context) (string, error) {
		return "ok", nil
	})
	err := rendezvous.WaitFirstError(context.Background(), aTask, bTask)
	if err != nil {
		log.Fatal(err)
	}
	a, b := <-aChan, <-bChan
	fmt.Println(a, b)
	// Output:
	// 42 ok
}
```